### PR TITLE
feat: added getTargetEntity to Character class

### DIFF
--- a/source/Character.ts
+++ b/source/Character.ts
@@ -2055,6 +2055,18 @@ export class Character extends Observer implements CharacterData {
     }
 
     /**
+     * Retrieves target entity
+     *
+     * @return {*}  {Entity}
+     * @memberof Character
+     */
+    public getTargetEntity(): Entity {
+        for (const [, entity] of this.entities) {
+            if (entity.id === this.target) return entity
+        }
+    }
+
+    /**
      * Retrieves tracker data
      *
      * @return {*}  {Promise<TrackerData>}


### PR DESCRIPTION
A way to quickly get the target `Entity` instead of just the target `id`.

Example usage: https://github.com/joeynenni/minstrel/blob/main/source/actions/kite.ts#L8