### PR TITLE
feat: added character.locateItemsByLevel

### DIFF
--- a/source/Character.ts
+++ b/source/Character.ts
@@ -3615,6 +3615,42 @@ export class Character extends Observer implements CharacterData {
         return found
     }
 
+    /**
+     * Returns an object with keys for each item name.
+     * Each item object has keys for each level.
+     * Each level object is an array of item positions.
+     *
+     * @param inventory Where to look for the item
+     * @param filters Options for sorting and filtering
+     */
+    public locateItemsByLevel(inventory = this.items, options?: { minAmount?: number }): {
+        [name in ItemName]?: {
+            [level in number]?: number[];
+        }
+    } {
+        const itemsByLevel = inventory.reduce((items, item, slotNum) => {
+            if (item) {
+                const { name, level } = item
+                items[name] = items[name] || {}
+                items[name][level] = [...(items[name][level] || []), slotNum]
+            }
+            return items
+        }, {})
+
+        // Remove any items that do not meet the minimum amount
+        if (options?.minAmount) {
+            for (const itemName in itemsByLevel) {
+                for (const itemLevel in itemsByLevel[itemName]) {
+                    if (itemsByLevel[itemName][itemLevel].length < options?.minAmount) delete itemsByLevel[itemName][itemLevel]
+                }
+
+                if (!Object.keys(itemsByLevel[itemName]).length) delete itemsByLevel[itemName]
+            }
+        }
+
+        return itemsByLevel
+    }
+
     public locateMonster(mType: MonsterName): NodeData[] {
         const locations: NodeData[] = []
 


### PR DESCRIPTION
`character.locateDuplicateItems()` was not working as intended, some duplicate items were not being returned. Another issue is that the duplicate items were not grouped by level which is very useful information for compounding.

I added a new function `character.locateItemsByLevel()` that addresses these issues.

Sample output looks something like this: (they are all level 1 items)
```
{
  "hpamulet": {
    "1": [
      0,
      1,
      2,
      4,
      6,
      9,
      12,
      13,
      14,
      15,
      16,
      19,
      20,
      21,
      26,
      29,
      31,
      35
    ]
  },
  "hpbelt": {
    "1": [
      5,
      7,
      8,
      10,
      11,
      17,
      18,
      22,
      23,
      24,
      25,
      32,
      34,
      36,
      39,
      40,
      41
    ]
  },
  "ringsj": {
    "1": [
      27,
      28,
      30,
      33,
      37,
      38
    ]
  }
}
```