### PR TITLE
Added sendPM and say functions

### DIFF
--- a/source/definitions/adventureland-server.ts
+++ b/source/definitions/adventureland-server.ts
@@ -226,6 +226,30 @@ export type CMData = {
     message: string
 }
 
+export type PMData = {
+    /* The name of the sending player */
+    owner: string,
+    /* The player the message is being sent to */
+    to: string, 
+    /* The message of the sending player */
+    message: string, 
+    /* The ID (name) Of the sending player */
+    id: string, 
+    /* Denotes whether this message has been sent cross server */
+    xserver?: string
+}
+
+export type ChatLogData = {
+    /* The name of the sending player */
+    owner: string,
+    /* The message of the sending player */
+    message: string, 
+    /* The ID (name) Of the sending player */
+    id: string, 
+    /* Player */
+    p?: boolean    
+}
+
 export type DeathData = {
     id: string
     place?: string | "attack"


### PR DESCRIPTION
added `sendPM` and `say` functions to the Character class. 

Although they both emit a `say` the erroring is slightly different. 
Also thought it was nice having separate functions to prevent accidently sending a public message if the `to` property is missing