### PR TITLE
smartMove adjustment, blink and taunt fix

### DIFF
--- a/source/Character.ts
+++ b/source/Character.ts
@@ -3014,17 +3014,17 @@ export class Character extends Observer implements CharacterData {
                     const potentialMove = path[j]
                     if (potentialMove.map == this.map) {
                         if (Tools.distance(currentMove, potentialMove) < (this.speed * 2)) break // We're close, don't waste a blink
+                        await (this as unknown as Mage).blink(potentialMove.x, potentialMove.y).catch(async (error) => {
+                            console.log(`Error blinking while smartMoving: ${error}, attempting 1 more time`)
+                            await new Promise(resolve => setTimeout(resolve, 1000))
+                            await (this as unknown as Mage).blink(potentialMove.x, potentialMove.y).catch((err) => {
+                                console.error("Failed blinking while smartMoving", err)
+                            })
+                        })
                         this.stopWarpToTown()?.catch(() => { /* Suppress errors */ })
-                        try {
-                            await (this as unknown as Mage).blink(potentialMove.x, potentialMove.y)
-                            i = j
-                            blinked = true
-                            break
-                        } catch (e) {
-                            console.error(e)
-                            blinked = false
-                            break
-                        }
+                        i = j
+                        blinked = true
+                        break
                     }
                 }
                 if (blinked) continue
@@ -3078,19 +3078,16 @@ export class Character extends Observer implements CharacterData {
                 } else if (currentMove.type == "transport") {
                     await this.transport(currentMove.map, currentMove.spawn)
                 }
-                numAttempts = 0
+                numAttempts = 0;
             } catch (e) {
                 console.error(e)
-                await this.requestPlayerData().catch((e) => { console.error(e) })
-
-                numAttempts += 1
-                if (numAttempts >= 3) {
+                numAttempts++
+                if(numAttempts >= 3){
                     this.smartMoving = undefined
                     return Promise.reject("We are having some trouble smartMoving...")
                 }
-
+                await this.requestPlayerData().catch((e) => { console.error(e) })
                 i--
-                continue
             }
         }
 

--- a/source/Character.ts
+++ b/source/Character.ts
@@ -3088,6 +3088,8 @@ export class Character extends Observer implements CharacterData {
                 }
                 await this.requestPlayerData().catch((e) => { console.error(e) })
                 i--
+                await new Promise(resolve => setTimeout(resolve, Constants.TIMEOUT))
+
             }
         }
 

--- a/source/Mage.ts
+++ b/source/Mage.ts
@@ -35,7 +35,7 @@ export class Mage extends PingCompensatedCharacter {
 
         const blinked = new Promise<void>((resolve, reject) => {
             const successCheck = (data: NewMapData) => {
-                if (data.effect == "blink" && data.x == x && data.y == y) {
+                if (data.effect == "blink") {
                     this.socket.off("new_map", successCheck)
                     this.socket.off("game_response", failCheck)
                     resolve()

--- a/source/Warrior.ts
+++ b/source/Warrior.ts
@@ -257,7 +257,6 @@ export class Warrior extends PingCompensatedCharacter {
         return stomped
     }
 
-    // TODO: Investigate if cooldown is before or after the "action" event. We are getting lots of "failed due to cooldowns"
     public taunt(target: string): Promise<string> {
         if (!this.ready) return Promise.reject("We aren't ready yet [taunt].")
         const tauntStarted = new Promise<string>((resolve, reject) => {
@@ -280,7 +279,7 @@ export class Warrior extends PingCompensatedCharacter {
                         this.socket.off("action", tauntCheck)
                         this.socket.off("game_response", failCheck)
                         reject(`${target} is too far away to taunt (dist: ${data.dist}).`)
-                    } else if (data.response == "cooldown" && data.id == target) {
+                    } else if (data.response == "cooldown" && data.id == target && data.skill == "taunt") {
                         this.socket.off("action", tauntCheck)
                         this.socket.off("game_response", failCheck)
                         reject(`Taunt on ${target} failed due to cooldown (ms: ${data.ms}).`)


### PR DESCRIPTION
- SmartMove adjustment
After pulling the latest version of ALClient my mage who scouts the map runs into water or a mountain and dies right after blinking. 
This happens as soon as a blink occurs, but works fine up until then. 
Small adjustment to the latest smartMove change to just attempt a retry once if the blink fails and then move on

- Mage blink fix. 
While looking into the issue above I noticed mage blink will actually timeout every time. This is one of the main factors causing `smartMove` to reject, as blink fails.

The below are the socket events that emit for a blink
The coordinates requested for the blink, and the coordinates returned from the blink event do not match. 
So the `successCheck` will always fail as it's looking for an exact match. 

I've removed the coordinate check, as even if i tried matching if the coordinates are more or less the same sometimes the result coordinates varies greatly, but we've still blinked!


![image](https://user-images.githubusercontent.com/29847637/151507213-4f63f918-4074-4f84-98cd-3dd28903d533.png)


- Warrior taunt fix
Added a check to `failCheck` due to cooldown to make sure the skill is `taunt`
As the cooldown fail check is giving a false positive as other skills emit `cooldown` events too.
The best example is the basic auto-attack.
The below two events both trigger the cooldown rejection for the taunt skill. 

Taunt Cooldown event: `{response: "cooldown", skill: "taunt", place: "taunt", id: "1220789", ms: 2779}`
Basic Attack Cooldown event: `{response: "cooldown", place: "attack", id: "1220789", ms: 690}`