### PR TITLE
improved buyWithTokens to check all token types

### DIFF
--- a/source/Character.ts
+++ b/source/Character.ts
@@ -983,10 +983,12 @@ export class Character extends Observer implements CharacterData {
     public async buyWithTokens(itemName: ItemName): Promise<void> {
         const numBefore = this.countItem(itemName)
 
+        const tokenTypes = ["monstertoken", "pvptoken", "funtoken"]
+
         // Check if this item is buyable with tokens, and if we have enough
         let tokenTypeNeeded: "funtoken" | "monstertoken" | "pvptoken"
         let numTokensNeeded: number
-        for (const t in this.G.tokens) {
+        for (const t in tokenTypes) {
             const tokenType = t as "funtoken" | "monstertoken" | "pvptoken"
             const tokenTable = this.G.tokens[tokenType]
             for (const item in tokenTable) {


### PR DESCRIPTION
Created an object before the search to hold the number of each token type owned, the npc location for said token type, and the error for each of the three token types. During the search, if we are too far from the required npc, we set the error to say such; or, if we are close enough but don't have enough of said token, we set the error to say such. If we don't find the item during the search, we set the error to say that the item can't be purchased with said token type. At the end, if all three token types have errors, then we throw an AggregateError containing all three errors; otherwise, we proceed using whichever token type had a success.