### PR TITLE
Fix `ignoreIDs` for `Character.getPlayers()`

### DIFF
--- a/source/Character.ts
+++ b/source/Character.ts
@@ -3537,8 +3537,12 @@ export class Character extends Observer implements CharacterData {
 
     public getPlayers(filters: GetPlayersFilters = {}): Player[] {
         const players: Player[] = []
-
-        for (const [, player] of this.players) {
+        filterCheck: for (const [, player] of this.players) {
+            if (filters.ignoreIDs !== undefined) {
+                for (const id of filters.ignoreIDs) {
+                    if (id == player.id) continue filterCheck
+                }
+            }
             if (filters.ctype !== undefined && player.ctype !== filters.ctype) continue
             if (filters.isDead !== undefined) {
                 const rip = player.rip
@@ -3564,11 +3568,6 @@ export class Character extends Observer implements CharacterData {
                 const partyMember = player.party == this.party
                 if (filters.isPartyMember && !partyMember) continue
                 if (!filters.isPartyMember && partyMember) continue
-            }
-            if (filters.ignoreIDs !== undefined) {
-                for (const id in filters.ignoreIDs) {
-                    if (id == player.id) continue
-                }
             }
             if (filters.targetingMe !== undefined) {
                 if (filters.targetingMe) {


### PR DESCRIPTION
Just applied the the fix made on this commit [https://github.com/earthiverse/ALClient/commit/277b81a3539116d2f30b3afcc08f68034c5ab19e](https://github.com/earthiverse/ALClient/commit/277b81a3539116d2f30b3afcc08f68034c5ab19e) to \`Character.getPlayers()\`.

In summary, the `continue` inside the nested `for loop` iterating on `ignoreIDs` wasn't affecting the outer loop as it should have.

Additionally the nested loop was of the `for...in` format instead of `for...of`.